### PR TITLE
Update GitHub Actions to use v4 for artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             echo "BIN=ytcli" >> $GITHUB_ENV
           fi
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ytcli-${{ runner.os }}
           path: target/release/${{ env.BIN }}
@@ -37,7 +37,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: dist
       - name: List artifacts


### PR DESCRIPTION
Upgraded actions/upload-artifact and actions/download-artifact from v3 to v4 in release workflow for improved performance and latest features.