### PR TITLE
Specify bash shell for binary name step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         run: cargo build --release
       - name: Prepare binary name
         id: prep
+        shell: bash
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
             echo "BIN=ytcli.exe" >> $GITHUB_ENV


### PR DESCRIPTION
Adds 'shell: bash' to the 'Prepare binary name' step in the release workflow to ensure consistent shell behavior across platforms.