### PR TITLE
Trigger release workflow only on main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 


### PR DESCRIPTION
Updated the release workflow to run on pushes to the main branch and tags matching 'v*', ensuring releases are only triggered from the main branch.